### PR TITLE
Atualização do link de acesso ao manual

### DIFF
--- a/Cap01/JupyterNotebook-ManualUsuario.ipynb
+++ b/Cap01/JupyterNotebook-ManualUsuario.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Manual Jupyter Notebook:\n",
     "\n",
-    "https://athena.brynmawr.edu/jupyter/hub/dblank/public/Jupyter%20Notebook%20Users%20Manual.ipynb"
+    "https://jupyter.brynmawr.edu/services/public/dblank/Jupyter%20Notebook%20Users%20Manual.ipynb"
    ]
   },
   {


### PR DESCRIPTION
O antigo link de acesso ao manual mudou. Não é mais possível acessar ao manual através do link antigo.